### PR TITLE
chore: @babel/core and @babel/preset-env should not be listed as prod…

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,9 +41,7 @@
   },
   "homepage": "https://github.com/serpwow/google-search-results-nodejs#readme",
   "dependencies": {
-    "@babel/core": "^7.0.0",
     "@babel/polyfill": "^7.0.0",
-    "@babel/preset-env": "^7.0.0",
     "node-fetch": "^2.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
…uction dependencies

Hello here!

We'd like to use this package but we don't want to add dev dependencies such as @babel/core or @babel/preset-env in our production bundle.
